### PR TITLE
Change main class in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ jar {
     archivesBaseName = "ThreeLayerApp"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest {
-        attributes "Main-class": "edu.virginia.cs.threelayer.presentation.args.Main"
+        attributes "Main-class": "edu.virginia.cs.threelayer.presentation.CommandLineArgs"
     }
 
     from {


### PR DESCRIPTION
I was looking through this codebase ahead of guest lecturing about architecture this week. It seems like the classes were moved under `edu.virginia.cs.threelayer.presentation` in [this commit](https://github.com/sde-coursepack/ThreeLayerBooks/commit/f32b69425a6719945ecbfe532ee35257efaba717) but `build.gradle` was never updated, causing a `ClassNotFoundException` when the JAR is run. This change updates `build.gradle` to use the correct main class name, causing the JAR to run properly again.